### PR TITLE
Correct float isEven/isOdd implementation

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -1,7 +1,11 @@
 package ensure
 
-// Export these internal functions so they can be access by the test suite
+// Export these internal functions so they can be accessed by the test suite
 
-func IsEven[T NumberType](typeStr string, i T) bool {
-	return isEven[T](typeStr, i)
+func IsEven(typeStr string, i any) bool {
+	return isEven(typeStr, i)
+}
+
+func IsOdd(typeStr string, i any) bool {
+	return isOdd(typeStr, i)
 }


### PR DESCRIPTION
The implementation of the isEven() function includes a check on float values that returns false for nearly all situations.  The only "even" float is one that has a zero decimal component and an even whole component.  Since negation of the isEven() function is used determine whether a number is odd, this resulted in a lot of false positives when checking whether a float is odd.  This PR fixes that by creating separate functions for determining evenness and oddness, as well as some additional test cases to ensure they work as expected.