### PR TITLE
Add test for TypeError.Error()

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -9,3 +9,7 @@ func IsEven(typeStr string, i any) bool {
 func IsOdd(typeStr string, i any) bool {
 	return isOdd(typeStr, i)
 }
+
+func NewTypeError(msg string) TypeError {
+	return TypeError{err: msg}
+}

--- a/types_test.go
+++ b/types_test.go
@@ -1,0 +1,16 @@
+package ensure_test
+
+import (
+	"github.com/chriscasto/go-ensure"
+	"testing"
+)
+
+func TestTypeError_Error(t *testing.T) {
+	// This is really just a formality to quiet the coverage checker
+	msg := "test"
+	err := ensure.NewTypeError(msg)
+
+	if err.Error() != msg {
+		t.Errorf("TypeError.Error() = `%s`, want `%s`", err.Error(), msg)
+	}
+}


### PR DESCRIPTION
The coverage checker has been whining about missing tests for `TypeError.Error()`, even though all it is is a one-liner that returns a single struct field.  This just adds in a basic test to complete the code coverage for the `ensure` package.