### PR TITLE
Add validator for arrays of comparable types

### DIFF
--- a/array.go
+++ b/array.go
@@ -149,3 +149,24 @@ func (cv *ComparableArrayValidator[T]) DoesNotContain(item T) *ComparableArrayVa
 	})
 	return cv
 }
+
+// ContainsOnly causes a validation error if the array contains any value not in the provided list
+func (cv *ComparableArrayValidator[T]) ContainsOnly(items []T) *ComparableArrayValidator[T] {
+	allow := map[T]bool{}
+
+	for _, item := range items {
+		allow[item] = true
+	}
+
+	cv.checks.Append(func(val []T, _ *with.ValidationOptions) error {
+		for _, v := range val {
+			_, ok := allow[v]
+			if !ok {
+				return fmt.Errorf(`array must contain only allowed values; value "%v" not allowed`, v)
+			}
+		}
+
+		return nil
+	})
+	return cv
+}

--- a/array.go
+++ b/array.go
@@ -161,9 +161,30 @@ func (cv *ComparableArrayValidator[T]) ContainsOnly(items []T) *ComparableArrayV
 	cv.checks.Append(func(val []T, _ *with.ValidationOptions) error {
 		for _, v := range val {
 			_, ok := allow[v]
+
 			if !ok {
 				return fmt.Errorf(`array must contain only allowed values; value "%v" not allowed`, v)
 			}
+		}
+
+		return nil
+	})
+	return cv
+}
+
+// ContainsNoDuplicates causes a validation error if the array contains any duplicates
+func (cv *ComparableArrayValidator[T]) ContainsNoDuplicates() *ComparableArrayValidator[T] {
+	cv.checks.Append(func(val []T, _ *with.ValidationOptions) error {
+		found := map[T]bool{}
+
+		for _, v := range val {
+			_, ok := found[v]
+
+			if ok {
+				return fmt.Errorf(`array must not contain duplicate values; value "%v" is repeated`, v)
+			}
+
+			found[v] = true
 		}
 
 		return nil

--- a/array.go
+++ b/array.go
@@ -191,3 +191,47 @@ func (cv *ComparableArrayValidator[T]) ContainsNoDuplicates() *ComparableArrayVa
 	})
 	return cv
 }
+
+// ContainsAnyOf causes a validation error if at least one of the provided values is not in the array
+func (cv *ComparableArrayValidator[T]) ContainsAnyOf(items []T) *ComparableArrayValidator[T] {
+	expect := map[T]bool{}
+
+	for _, item := range items {
+		expect[item] = true
+	}
+
+	cv.checks.Append(func(val []T, _ *with.ValidationOptions) error {
+		for _, v := range val {
+			_, ok := expect[v]
+
+			if ok {
+				return nil
+			}
+		}
+
+		return fmt.Errorf(`array must contain one of the expected values`)
+	})
+	return cv
+}
+
+// DoesNotContainAnyOf causes a validation error if at least one of the provided values is in the array
+func (cv *ComparableArrayValidator[T]) DoesNotContainAnyOf(items []T) *ComparableArrayValidator[T] {
+	expect := map[T]bool{}
+
+	for _, item := range items {
+		expect[item] = true
+	}
+
+	cv.checks.Append(func(val []T, _ *with.ValidationOptions) error {
+		for _, v := range val {
+			_, ok := expect[v]
+
+			if ok {
+				return fmt.Errorf(`array must not contain any prohibited values`)
+			}
+		}
+
+		return nil
+	})
+	return cv
+}

--- a/array.go
+++ b/array.go
@@ -151,7 +151,7 @@ func (cv *ComparableArrayValidator[T]) DoesNotContain(item T) *ComparableArrayVa
 }
 
 // ContainsOnly causes a validation error if the array contains any value not in the provided list
-func (cv *ComparableArrayValidator[T]) ContainsOnly(items []T) *ComparableArrayValidator[T] {
+func (cv *ComparableArrayValidator[T]) ContainsOnly(items ...T) *ComparableArrayValidator[T] {
 	allow := map[T]bool{}
 
 	for _, item := range items {
@@ -193,7 +193,7 @@ func (cv *ComparableArrayValidator[T]) ContainsNoDuplicates() *ComparableArrayVa
 }
 
 // ContainsAnyOf causes a validation error if at least one of the provided values is not in the array
-func (cv *ComparableArrayValidator[T]) ContainsAnyOf(items []T) *ComparableArrayValidator[T] {
+func (cv *ComparableArrayValidator[T]) ContainsAnyOf(items ...T) *ComparableArrayValidator[T] {
 	expect := map[T]bool{}
 
 	for _, item := range items {
@@ -215,7 +215,7 @@ func (cv *ComparableArrayValidator[T]) ContainsAnyOf(items []T) *ComparableArray
 }
 
 // DoesNotContainAnyOf causes a validation error if at least one of the provided values is in the array
-func (cv *ComparableArrayValidator[T]) DoesNotContainAnyOf(items []T) *ComparableArrayValidator[T] {
+func (cv *ComparableArrayValidator[T]) DoesNotContainAnyOf(items ...T) *ComparableArrayValidator[T] {
 	expect := map[T]bool{}
 
 	for _, item := range items {

--- a/array_test.go
+++ b/array_test.go
@@ -237,6 +237,22 @@ func TestComparableArrayValidator_ContainsOnly(t *testing.T) {
 	)
 }
 
+func TestComparableArrayValidator_ContainsNoDuplicates(t *testing.T) {
+	testCases := arrayTestCases[int]{
+		"empty":       {[]int{}, true},
+		"one":         {[]int{1}, true},
+		"one two":     {[]int{1, 2}, true},
+		"repeat one":  {[]int{1, 2, 1}, false},
+		"just threes": {[]int{3, 3, 3, 3}, false},
+	}
+
+	testCases.run(
+		t,
+		ensure.ComparableArray[int]().ContainsNoDuplicates(),
+		"ContainsNoDuplicates()",
+	)
+}
+
 func TestArrayValidator_MultiError(t *testing.T) {
 	type exampleArr = []int
 

--- a/array_test.go
+++ b/array_test.go
@@ -237,6 +237,40 @@ func TestComparableArrayValidator_ContainsOnly(t *testing.T) {
 	)
 }
 
+func TestComparableArrayValidator_ContainsAnyOf(t *testing.T) {
+	testCases := arrayTestCases[int]{
+		"empty":    {[]int{}, false},
+		"one":      {[]int{1}, false},
+		"one two":  {[]int{1, 2}, true},
+		"two four": {[]int{2, 4}, true},
+		"just two": {[]int{2}, true},
+		"threes":   {[]int{3, 6, 9}, true},
+	}
+
+	testCases.run(
+		t,
+		ensure.ComparableArray[int]().ContainsAnyOf([]int{2, 3}),
+		"ContainsAnyOf()",
+	)
+}
+
+func TestComparableArrayValidator_DoesNotContainAnyOf(t *testing.T) {
+	testCases := arrayTestCases[int]{
+		"empty":    {[]int{}, true},
+		"one":      {[]int{1}, true},
+		"one two":  {[]int{1, 2}, false},
+		"two four": {[]int{2, 4}, false},
+		"just two": {[]int{2}, false},
+		"threes":   {[]int{3, 6, 9}, false},
+	}
+
+	testCases.run(
+		t,
+		ensure.ComparableArray[int]().DoesNotContainAnyOf([]int{2, 3}),
+		"DoesNotContainAnyOf()",
+	)
+}
+
 func TestComparableArrayValidator_ContainsNoDuplicates(t *testing.T) {
 	testCases := arrayTestCases[int]{
 		"empty":       {[]int{}, true},

--- a/array_test.go
+++ b/array_test.go
@@ -29,7 +29,7 @@ func testArrayType[T any](t *testing.T, name string, expect string) {
 
 type arrayTestCases[T any] map[string]arrayTestCase[T]
 
-func (tcs arrayTestCases[T]) run(t *testing.T, av *ensure.ArrayValidator[T], method string) {
+func (tcs arrayTestCases[T]) run(t *testing.T, av with.Validator[[]T], method string) {
 	for name, tc := range tcs {
 		t.Run(name, func(t *testing.T) {
 			err := av.Validate(tc.vals)
@@ -183,6 +183,40 @@ func TestArrayValidator_Is(t *testing.T) {
 		t,
 		ensure.Array[int]().Has(increasingSequence),
 		"Has()",
+	)
+}
+
+func TestComparableArrayValidator_Contains(t *testing.T) {
+	testCases := arrayTestCases[int]{
+		"empty":    {[]int{}, false},
+		"one":      {[]int{1}, false},
+		"one two":  {[]int{1, 2}, true},
+		"two four": {[]int{2, 4}, true},
+		"just two": {[]int{2}, true},
+		"threes":   {[]int{3, 6, 9}, false},
+	}
+
+	testCases.run(
+		t,
+		ensure.ComparableArray[int]().Contains(2),
+		"Contains()",
+	)
+}
+
+func TestComparableArrayValidator_DoesNotContain(t *testing.T) {
+	testCases := arrayTestCases[int]{
+		"empty":    {[]int{}, true},
+		"one":      {[]int{1}, true},
+		"one two":  {[]int{1, 2}, false},
+		"two four": {[]int{2, 4}, false},
+		"just two": {[]int{2}, false},
+		"threes":   {[]int{3, 6, 9}, true},
+	}
+
+	testCases.run(
+		t,
+		ensure.ComparableArray[int]().DoesNotContain(2),
+		"DoesNotContain()",
 	)
 }
 

--- a/array_test.go
+++ b/array_test.go
@@ -232,7 +232,7 @@ func TestComparableArrayValidator_ContainsOnly(t *testing.T) {
 
 	testCases.run(
 		t,
-		ensure.ComparableArray[int]().ContainsOnly([]int{1, 2}),
+		ensure.ComparableArray[int]().ContainsOnly(1, 2),
 		"ContainsOnly()",
 	)
 }
@@ -249,7 +249,7 @@ func TestComparableArrayValidator_ContainsAnyOf(t *testing.T) {
 
 	testCases.run(
 		t,
-		ensure.ComparableArray[int]().ContainsAnyOf([]int{2, 3}),
+		ensure.ComparableArray[int]().ContainsAnyOf(2, 3),
 		"ContainsAnyOf()",
 	)
 }
@@ -266,7 +266,7 @@ func TestComparableArrayValidator_DoesNotContainAnyOf(t *testing.T) {
 
 	testCases.run(
 		t,
-		ensure.ComparableArray[int]().DoesNotContainAnyOf([]int{2, 3}),
+		ensure.ComparableArray[int]().DoesNotContainAnyOf(2, 3),
 		"DoesNotContainAnyOf()",
 	)
 }

--- a/array_test.go
+++ b/array_test.go
@@ -220,6 +220,23 @@ func TestComparableArrayValidator_DoesNotContain(t *testing.T) {
 	)
 }
 
+func TestComparableArrayValidator_ContainsOnly(t *testing.T) {
+	testCases := arrayTestCases[int]{
+		"empty":    {[]int{}, true},
+		"one":      {[]int{1}, true},
+		"one two":  {[]int{1, 2}, true},
+		"two four": {[]int{2, 4}, false},
+		"just two": {[]int{2}, true},
+		"threes":   {[]int{3, 6, 9}, false},
+	}
+
+	testCases.run(
+		t,
+		ensure.ComparableArray[int]().ContainsOnly([]int{1, 2}),
+		"ContainsOnly()",
+	)
+}
+
 func TestArrayValidator_MultiError(t *testing.T) {
 	type exampleArr = []int
 

--- a/docs/arrays.md
+++ b/docs/arrays.md
@@ -34,3 +34,38 @@ validator := ensure.Array[string]().Each(
 | HasLengthWhere(v)    | Adds a number validator that evaluates against the length of the array    |
 | Each(v)              | Passes if the provided validator passes for each element in the array     |
 | Is(func ([]T) error) | Passes if the function passed does not produce an error during validation |
+
+# Comparable Arrays
+
+There is a subtype of array validator that can apply additional checks on 
+`comparable` types.  It has all the methods available on the array validator,
+with the addition of some that can only be used on types that support equality
+operations.
+
+```go
+validStr := ensure.ComparableArray[string]().Contains("one")
+
+// no error
+validStr.Validate([]string{
+    "three", 
+    "two",
+    "one",
+    "zero",
+})
+
+// this returns an error
+validStr.Validate([]string{
+    "foo",
+    "bar",
+    "baz",
+})
+```
+
+| Method                    | Description                                                            |
+|---------------------------|------------------------------------------------------------------------|
+| Contains(T)               | Passes if tested array contains the passed value                       |
+| DoesNotContain(T)         | Passes if tested array does not contain the passed value               |
+| ContainsAnyOf(...T)       | Passes if tested array contains any of the passed values               |
+| DoesNotContainAnyOf(...T) | Passes if tested array does not contain any of the passed values       |
+| ContainsNoDuplicates()    | Passes if tested array does not contain any duplicate values           |
+| ContainsOnly(...T)        | Passes if the values in the array are exclusively from the passed list |


### PR DESCRIPTION
This PR adds the ComparableArrayValidator struct and various Contains* methods for evaluating arrays of values that are considered `comparable`

Resolves #12 
Resolves #3 